### PR TITLE
Remove the patch number from dune lang version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.4.0)
+(lang dune 2.4)
 (name bastet_lwt)
 (source (github Risto-Stevcev/bastet-lwt))
 (license BSD-3-Clause)


### PR DESCRIPTION
This part of the version number is ignored by dune and results in a
warning 'The ".0" part is ignored here'
